### PR TITLE
Disable expanding header

### DIFF
--- a/kn/base/media/common.js
+++ b/kn/base/media/common.js
@@ -1,6 +1,7 @@
 var collapsedHeaderHeight = 70;
 var headerHeight = 400;
 var headerCollapsed = true;
+var expandHeader = true;
 
 function email(t, d, u) {
     var email = u + '@' + d + '.' + t;
@@ -88,41 +89,44 @@ $(document).ready(function() {
         return false;
     });
 
-    /* reduce flicker on page load by loading the page with the header collapsed
-     * and expanding it with JS while scrolling to the right position */
-    $(document.body).addClass('header-expanded');
-    var headerFixedThreshold = headerHeight - collapsedHeaderHeight;
+    if (expandHeader) {
+        /* reduce flicker on page load by loading the page with the header collapsed
+         * and expanding it with JS while scrolling to the right position */
+        $(document.body).addClass('header-expanded');
+        var headerFixedThreshold = headerHeight - collapsedHeaderHeight;
 
-    // Skip to content after first view.
-    // Scrolling needs the media queries to work. Media queries don't work in
-    // IE8, and getComputedStyle doesn't work either so this is a test to
-    // exclude old browsers.
-    if (sessionStorage['visited'] && window.getComputedStyle &&
-        getComputedStyle(document.body).paddingTop == headerHeight + "px") {
-        $(document.body).addClass('viewedBefore');
-        // <html> for Firefox, <body> for other browsers
-        document.documentElement.scrollTop = headerFixedThreshold;
-        document.body.scrollTop = headerFixedThreshold;
-    }
-    sessionStorage['visited'] = 'true';
+        // Skip to content after first view.
+        // Scrolling needs the media queries to work. Media queries don't work in
+        // IE8, and getComputedStyle doesn't work either so this is a test to
+        // exclude old browsers.
+        if (sessionStorage['visited'] && window.getComputedStyle &&
+            getComputedStyle(document.body).paddingTop == headerHeight + "px") {
+            $(document.body).addClass('viewedBefore');
+            // <html> for Firefox, <body> for other browsers
+            document.documentElement.scrollTop = headerFixedThreshold;
+            document.body.scrollTop = headerFixedThreshold;
+        }
 
-    function fixHeader() {
-        var shouldBeCollapsed = $(window).scrollTop() > headerFixedThreshold;
-        if (headerCollapsed !== shouldBeCollapsed) {
-            // don't touch the DOM if that's not needed!
-            headerCollapsed = shouldBeCollapsed;
-            if (shouldBeCollapsed) {
-                $('#header').addClass('fixed');
-            } else {
-                $('#header').removeClass('fixed');
+        function fixHeader() {
+            var shouldBeCollapsed = $(window).scrollTop() > headerFixedThreshold;
+            if (headerCollapsed !== shouldBeCollapsed) {
+                // don't touch the DOM if that's not needed!
+                headerCollapsed = shouldBeCollapsed;
+                if (shouldBeCollapsed) {
+                    $('#header').addClass('fixed');
+                } else {
+                    $('#header').removeClass('fixed');
+                }
             }
         }
+        // Menubar half-fixed
+        if (! isMobile()) {
+            $(window).scroll(fixHeader);
+            fixHeader();
+        }
     }
-    // Menubar half-fixed
-    if (! isMobile()) {
-        $(window).scroll(fixHeader);
-        fixHeader();
-    }
+
+    sessionStorage['visited'] = 'true';
 
     $('#loginButtonLink').bind('click', function (event) {
         var loginButton = $('#loginButton');

--- a/kn/fotos/templates/fotos/fotos.html
+++ b/kn/fotos/templates/fotos/fotos.html
@@ -7,10 +7,9 @@
 </script>
 <script type="text/javascript">
 'use strict';
+expandHeader = false;
 var fotos_root = "{% url fotos '' %}";
 var fotos_api_url = "{% url fotos-api %}";
-// FIXME (hack) this forces the header to be collapsed.
-sessionStorage['visited'] = true;
 // Initialize Lazy Load XT
 $.extend($.lazyLoadXT, {
   autoInit: false,


### PR DESCRIPTION
Doe het volledig in plaats van via een hack.
Ik betwijfel ook of die header eigenlijk wel zo zou moeten blijven. We zouden de header bijvoorbeeld alleen op de homepage kunnen uitklappen en op de rest van de pagina's altijd ingeklapt laten. Persoonlijk vind ik het scrollen tijdens het laden best irritant.
Maar dat is een aparte zaak. In het fotoboek is het zeker niet handig.