### PR TITLE
Fotos sizes

### DIFF
--- a/kn/fotos/api.py
+++ b/kn/fotos/api.py
@@ -30,8 +30,9 @@ def album_json(album, user):
             entry['thumbnailSize'] = child.get_cache_size('thumb')
         elif child._type == 'album':
             album_foto = child.get_random_foto_for(user)
-            entry['thumbnailSize'] = album_foto.get_cache_size('thumb')
-            entry['thumbnailPath'] = album_foto.full_path
+            if album_foto is not None:
+                entry['thumbnailSize'] = album_foto.get_cache_size('thumb')
+                entry['thumbnailPath'] = album_foto.full_path
         json_children.append(entry)
 
     current_album = album

--- a/kn/fotos/api.py
+++ b/kn/fotos/api.py
@@ -25,13 +25,13 @@ def album_json(album, user):
                  'name': child.name,
                  'title': child.title}
         if child._type == 'foto':
-            entry['largeSize'] = child.get_cache_meta('large').get('size')
+            entry['largeSize'] = child.get_cache_size('large')
             if entry['largeSize'] is None:
-                size2x = child.get_cache_meta('large2x').get('size')
+                size2x = child.get_cache_size('large2x')
                 if size2x: entry['largeSize'] = [x/2 for x in size2x]
-            entry['thumbnailSize'] = child.get_cache_meta('thumb').get('size')
+            entry['thumbnailSize'] = child.get_cache_size('thumb')
             if entry['thumbnailSize'] is None:
-                size2x = child.get_cache_meta('thumb2x').get('size')
+                size2x = child.get_cache_size('thumb2x')
                 if size2x: entry['thumbnailSize'] = [x/2 for x in size2x]
         json_children.append(entry)
     return {'children': json_children}

--- a/kn/fotos/api.py
+++ b/kn/fotos/api.py
@@ -27,6 +27,10 @@ def album_json(album, user):
         if child._type == 'foto':
             entry['largeSize'] = child.get_cache_size('large')
             entry['thumbnailSize'] = child.get_cache_size('thumb')
+        elif child._type == 'album':
+            album_foto = child.get_random_foto_for(user)
+            entry['thumbnailSize'] = album_foto.get_cache_size('thumb')
+            entry['thumbnailPath'] = album_foto.full_path
         json_children.append(entry)
     return {'children': json_children}
 

--- a/kn/fotos/api.py
+++ b/kn/fotos/api.py
@@ -26,13 +26,7 @@ def album_json(album, user):
                  'title': child.title}
         if child._type == 'foto':
             entry['largeSize'] = child.get_cache_size('large')
-            if entry['largeSize'] is None:
-                size2x = child.get_cache_size('large2x')
-                if size2x: entry['largeSize'] = [x/2 for x in size2x]
             entry['thumbnailSize'] = child.get_cache_size('thumb')
-            if entry['thumbnailSize'] is None:
-                size2x = child.get_cache_size('thumb2x')
-                if size2x: entry['thumbnailSize'] = [x/2 for x in size2x]
         json_children.append(entry)
     return {'children': json_children}
 

--- a/kn/fotos/entities.py
+++ b/kn/fotos/entities.py
@@ -15,7 +15,7 @@ import subprocess
 from collections import namedtuple
 
 
-cache_tuple = namedtuple('cache_tuple', ('ext', 'mimetype', 'maxwidth', 'maxheight'))
+cache_tuple = namedtuple('cache_tuple', ('ext', 'mimetype', 'maxwidth', 'maxheight', 'quality'))
 
 fcol = db['fotos']
 lcol = db['fotoLocks']
@@ -251,11 +251,11 @@ class FotoAlbum(FotoEntity):
             r = 1
 
 class Foto(FotoEntity):
-    CACHES = {'thumb': cache_tuple('jpg', 'image/jpeg', 200, None),
-              'thumb2x': cache_tuple('jpg', 'image/jpeg', 400, None),
-              'large': cache_tuple('jpg', 'image/jpeg', 850, None),
-              'large2x': cache_tuple('jpg', 'image/jpeg', 1700, None),
-              'full': cache_tuple(None, None, None, None),
+    CACHES = {'thumb': cache_tuple('jpg', 'image/jpeg', 200, None, 85),
+              'thumb2x': cache_tuple('jpg', 'image/jpeg', 400, None, 85),
+              'large': cache_tuple('jpg', 'image/jpeg', 850, None, 90),
+              'large2x': cache_tuple('jpg', 'image/jpeg', 1700, None, 90),
+              'full': cache_tuple(None, None, None, None, None),
               }
 
 
@@ -312,8 +312,10 @@ class Foto(FotoEntity):
         size = '%dx%d' % self.get_cache_size(cache)
         subprocess.check_call(['convert',
                          source,
+                         '-strip',
                          '-rotate', str(self.rotation),
                          '-resize', size,
+                         '-quality', str(self.CACHES[cache].quality),
                          target])
 
 

--- a/kn/fotos/entities.py
+++ b/kn/fotos/entities.py
@@ -68,6 +68,7 @@ class FotoEntity(SONWrapper):
     title = son_property(('title',))
     created = son_property(('created',))
     rotation = son_property(('rotation',))
+    size = son_property(('size',))
 
     description = son_property(('description',))
     visibility = son_property(('visibility',))
@@ -240,7 +241,7 @@ class Foto(FotoEntity):
         '''
         Load EXIF metadata from file if it hasn't been loaded yet.
         '''
-        if not None in [self.rotation, self.created]:
+        if not None in [self.rotation, self.created, self.size]:
             return False
 
         img = Image.open(self.original_path)
@@ -268,6 +269,9 @@ class Foto(FotoEntity):
             self.created = settings.DT_MIN # NULL date/time
             if 'DateTimeOriginal' in exif:
                 self.created = datetime.datetime.strptime(exif['DateTimeOriginal'], '%Y:%m:%d %H:%M:%S')
+
+        if self.size is None:
+            self.size = img.size
 
         return True
 

--- a/kn/fotos/entities.py
+++ b/kn/fotos/entities.py
@@ -241,7 +241,7 @@ class Foto(FotoEntity):
         Load EXIF metadata from file if it hasn't been loaded yet.
         '''
         if not None in [self.rotation, self.created]:
-            return
+            return False
 
         img = Image.open(self.original_path)
         exif = {}
@@ -268,6 +268,8 @@ class Foto(FotoEntity):
             self.created = settings.DT_MIN # NULL date/time
             if 'DateTimeOriginal' in exif:
                 self.created = datetime.datetime.strptime(exif['DateTimeOriginal'], '%Y:%m:%d %H:%M:%S')
+
+        return True
 
 
     def _cache(self, cache):

--- a/kn/fotos/media/fotos.css
+++ b/kn/fotos/media/fotos.css
@@ -16,6 +16,11 @@ ul#fotos {
     clear: both;
 }
 
+ul#fotos a {
+    display: block;
+    min-height: 150px;
+}
+
 ul#fotos li {
     display: inline-block;
     width: 210px;

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -68,16 +68,20 @@
     for (var name in this.fotos[this.path]) {
       (function(name) {
         var c = this.fotos[this.path][name];
-        var srcset = c.thumbnail + " 1x, " +
-                     c.thumbnail2x + " 2x";
         var thumb = $('<li><a><img class="lazy" /></a></li>');
-        $('img', thumb)
-            .attr('data-srcset', srcset)
-            .attr('data-src', c.thumbnail);
-        if (c.thumbnailSize)
+        if (c.thumbnail !== undefined) {
+          var srcset = c.thumbnail + " 1x, " +
+                       c.thumbnail2x + " 2x";
           $('img', thumb)
-              .attr('width', c.thumbnailSize[0])
-              .attr('height', c.thumbnailSize[1]);
+              .attr('data-srcset', srcset)
+              .attr('data-src', c.thumbnail);
+          if (c.thumbnailSize)
+            $('img', thumb)
+                .attr('width', c.thumbnailSize[0])
+                .attr('height', c.thumbnailSize[1]);
+        } else {
+          $('a', thumb).text('(geen thumbnail)');
+        }
         var title = c.title;
         if (!title && c.type == 'album')
           title = c.name;
@@ -139,8 +143,10 @@
     var prev = null;
     $.each(data.children, function(i, c) {
       if (c.type == 'album') {
-        c.thumbnail = this.cache_url('thumb', c.thumbnailPath);
-        c.thumbnail2x = this.cache_url('thumb2x', c.thumbnailPath);
+        if (c.thumbnailPath !== undefined) {
+          c.thumbnail = this.cache_url('thumb', c.thumbnailPath);
+          c.thumbnail2x = this.cache_url('thumb2x', c.thumbnailPath);
+        }
       } else {
         c.thumbnail = this.cache_url('thumb', c.path);
         c.thumbnail2x = this.cache_url('thumb2x', c.path);

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -125,8 +125,13 @@
 
     var prev = null;
     $.each(data.children, function(i, c) {
-      c.thumbnail = this.cache_url('thumb', c.path);
-      c.thumbnail2x = this.cache_url('thumb2x', c.path);
+      if (c.type == 'album') {
+        c.thumbnail = this.cache_url('thumb', c.thumbnailPath);
+        c.thumbnail2x = this.cache_url('thumb2x', c.thumbnailPath);
+      } else {
+        c.thumbnail = this.cache_url('thumb', c.path);
+        c.thumbnail2x = this.cache_url('thumb2x', c.path);
+      }
       if (c.type == 'foto') {
         c.full = this.cache_url('full', c.path);
         c.large = this.cache_url('large', c.path);

--- a/kn/fotos/views.py
+++ b/kn/fotos/views.py
@@ -35,22 +35,16 @@ def cache(request, cache, path):
     path = unquote(path)
     if not cache in fEs.CACHE_TYPES:
         raise Http404
-    o = fEs.by_path(path)
-    if o is None:
+    entity = fEs.by_path(path)
+    if entity is None:
         raise Http404
-    if not o.may_view(request.user if request.user.is_authenticated()
+    if not entity.may_view(request.user if request.user.is_authenticated()
                         else None):
         raise PermissionDenied
-    if o._type == 'album':
-        f = o.get_random_foto_for(request.user
-                                    if request.user.is_authenticated()
-                                    else None)
-    else:
-        f = o
-    f.ensure_cached(cache)
-    resp = HttpResponse(FileWrapper(open(f.get_cache_path(cache))),
-                            mimetype=f.get_cache_mimetype(cache))
-    resp['Content-Length'] = os.path.getsize(f.get_cache_path(cache))
+    entity.ensure_cached(cache)
+    resp = HttpResponse(FileWrapper(open(entity.get_cache_path(cache))),
+                            mimetype=entity.get_cache_mimetype(cache))
+    resp['Content-Length'] = os.path.getsize(entity.get_cache_path(cache))
     return resp
 
 @login_required

--- a/utils/fotos/update.py
+++ b/utils/fotos/update.py
@@ -57,8 +57,8 @@ def scan(album):
                 foto.save()
             else:
                 foto = fotos[name]
-                foto.update_metadata()
-                foto.save()
+                if foto.update_metadata():
+                    foto.save()
 
     # TODO deleted albums
 


### PR DESCRIPTION
Het resultaat hiervan is dat van alle thumbnails de grootte al bekend is, ook al is er nog geen cache van gemaakt. Dit zorgt ervoor dat de pagina niet verspringt tijdens het laden van foto's als dat album nog niet gecachet is, en het verspringen van lijsten van albums.