### PR TITLE
Album visibility

### DIFF
--- a/kn/fotos/api.py
+++ b/kn/fotos/api.py
@@ -67,7 +67,9 @@ def _set_metadata(data, request):
         return {'error': 'missing title attribute'}
     if not isinstance(data['title'], basestring):
         return {'error': 'title should be string'}
-    title = data['title'] or None
+    title = data['title'].strip()
+    if not title:
+        title = None
 
     if 'visibility' not in data:
         return {'error': 'missing visibility attribute'}

--- a/kn/fotos/api.py
+++ b/kn/fotos/api.py
@@ -77,7 +77,6 @@ def _set_title(data, request):
         raise PermissionDenied
 
     album.set_title(title)
-    album.save()
     return {'Ok': True}
 
 ACTION_HANDLER_MAP = {

--- a/kn/fotos/api.py
+++ b/kn/fotos/api.py
@@ -66,7 +66,7 @@ def _set_title(data, request):
         return {'error': 'missing title attribute'}
     if not isinstance(data['title'], basestring):
         return {'error': 'title should be string'}
-    title = data['title']
+    title = data['title'] or None
 
     album = entity_from_request(data)
     if isinstance(album, basestring):

--- a/kn/fotos/api.py
+++ b/kn/fotos/api.py
@@ -74,7 +74,7 @@ def _set_metadata(data, request):
     if 'visibility' not in data:
         return {'error': 'missing visibility attribute'}
     if data['visibility'] not in ['world', 'leden', 'hidden']:
-        return {'error': 'visibility not recognized'}
+        return {'error': 'visibility not valid'}
     visibility = data['visibility']
 
     album = entity_from_request(data)

--- a/kn/fotos/entities.py
+++ b/kn/fotos/entities.py
@@ -235,14 +235,6 @@ class FotoAlbum(FotoEntity):
         r = random.random()
         required_visibility = self.required_visibility(user)
         while True:
-            import pprint
-            pprint.pprint(fcol.find(
-                    {'random': {'$lt': r},
-                     'path': {'$regex': re.compile(
-                                "^%s(/|$)" % re.escape(self.full_path))},
-                     'type': 'foto',
-                     'visibility': {'$in': tuple(required_visibility)}},
-                        sort=[('random',-1)]).explain())
             f = entity(fcol.find_one(
                     {'random': {'$lt': r},
                      'path': {'$regex': re.compile(

--- a/kn/fotos/entities.py
+++ b/kn/fotos/entities.py
@@ -92,7 +92,7 @@ class FotoEntity(SONWrapper):
     def required_visibility(self, user):
         if user is None:
             return frozenset(('world',))
-        if user == '!system' or 'webcie' in user.cached_groups_names:
+        if 'webcie' in user.cached_groups_names:
             return frozenset(('leden', 'world', 'hidden'))
         if 'leden' in user.cached_groups_names:
             return frozenset(('leden', 'world'))
@@ -224,6 +224,12 @@ class FotoAlbum(FotoEntity):
                            ).sort([('created', 1), ('name', 1)]))
 
         return albums+fotos
+
+    def list_all(self):
+        '''
+        Return all children regardless of visibility.
+        '''
+        return map(entity, fcol.find({'path': self.full_path}).sort('name', 1))
 
     def get_random_foto_for(self, user):
         r = random.random()

--- a/kn/fotos/entities.py
+++ b/kn/fotos/entities.py
@@ -205,8 +205,10 @@ class FotoEntity(SONWrapper):
             return None
         return by_path(self.path)
 
-    def set_title(self, title):
+    def set_title(self, title, save=True):
         self.title = title
+        if save:
+            self.save()
 
 class FotoAlbum(FotoEntity):
     def __init__(self, data):

--- a/kn/fotos/templates/fotos/fotos.html
+++ b/kn/fotos/templates/fotos/fotos.html
@@ -41,6 +41,12 @@ if ('srcset' in (new Image())) {
 {% if fotos_admin %}
 <div id="album-edit">
   <form>
+    <select id="album-visibility"
+      onchange="$('#album-edit-button').prop('disabled', false)">
+      <option value="world">Publiek</option>
+      <option value="leden">Alleen leden</option>
+      <option value="hidden">Fototaggers</option>
+    </select>
     <input id="album-title" type="text" name="album-title" title="Album titel"
       oninput="$('#album-edit-button').prop('disabled', false)"/>
     <button id="album-edit-button" disabled>Ok</button>

--- a/utils/fotos/update.py
+++ b/utils/fotos/update.py
@@ -40,24 +40,26 @@ def scan(album):
                     'name': name,
                     'random': random.random(),
                     'visibility': ['hidden']})
+                subalbum.update_metadata(album)
+                subalbum.save()
+            elif subalbum.update_metadata(album):
                 subalbum.save()
             scan(subalbum)
 
         elif os.path.splitext(name)[1][1:].lower() in extensions:
             # photo
-            if name not in fotos:
+            foto = fotos.get(name, None)
+            if foto is None:
                 foto = fEs.entity({
                     'type': 'foto',
                     'path': album.full_path,
                     'name': name,
                     'random': random.random(),
-                    'visibility': ['hidden']})
-                foto.update_metadata()
+                    'visibility': ['world']})
+                foto.update_metadata(album)
                 foto.save()
-            else:
-                foto = fotos[name]
-                if foto.update_metadata():
-                    foto.save()
+            elif foto.update_metadata(album):
+                foto.save()
 
     # TODO deleted albums
 
@@ -75,6 +77,9 @@ def main():
             'title': 'Karpe Noktem fotoalbum',
             'description': "De fotocollectie van Karpe Noktem",
             'visibility': ['world']})
+        album.update_metadata(None)
+        album.save()
+    elif album.update_metadata(None):
         album.save()
     scan(album)
 

--- a/utils/fotos/update.py
+++ b/utils/fotos/update.py
@@ -16,9 +16,8 @@ extensions = {
 }
 
 def list_album(album):
-    _fotos = album.list('!system')
     fotos = {}
-    for foto in _fotos:
+    for foto in album.list_all():
         fotos[foto.name] = foto
     return fotos
 

--- a/utils/fotos/update.py
+++ b/utils/fotos/update.py
@@ -40,9 +40,9 @@ def scan(album):
                     'name': name,
                     'random': random.random(),
                     'visibility': ['hidden']})
-                subalbum.update_metadata(album)
+                subalbum.update_metadata(album, save=False)
                 subalbum.save()
-            elif subalbum.update_metadata(album):
+            elif subalbum.update_metadata(album, save=False):
                 subalbum.save()
             scan(subalbum)
 
@@ -56,9 +56,9 @@ def scan(album):
                     'name': name,
                     'random': random.random(),
                     'visibility': ['world']})
-                foto.update_metadata(album)
+                foto.update_metadata(album, save=False)
                 foto.save()
-            elif foto.update_metadata(album):
+            elif foto.update_metadata(album, save=False):
                 foto.save()
 
     # TODO deleted albums

--- a/utils/one-shot/2014-09-27-import-fotos.py
+++ b/utils/one-shot/2014-09-27-import-fotos.py
@@ -15,13 +15,24 @@ def main():
     c.execute("SELECT id, name, path, humanname, visibility, description "
                         + "FROM fa_albums")
     print 'albums'
+    if fEs.by_path('') is None:
+        root = fEs.entity({
+            'type': 'album',
+            'name': '',
+            'path': None,
+            'random': random.random(),
+            'title': 'Karpe Noktem fotoalbum',
+            'description': "De fotocollectie van Karpe Noktem",
+            'visibility': ['world']})
+        root.update_metadata(None)
+        root.save()
     for oldId, name, path, humanName, visibility, description in c.fetchall():
         if visibility in ('lost', 'deleted'):
             continue
         if fEs.by_oldId('album', oldId) is not None:
             continue
         path = path.strip('/')
-        fEs.entity({
+        album = fEs.entity({
             'type': 'album',
             'oldId': oldId,
             'random': random.random(),
@@ -29,16 +40,9 @@ def main():
             'path': path,
             'title': humanName,
             'description': description,
-            'visibility': [visibility]}).save()
-    if fEs.by_path('') is None:
-        fEs.entity({
-            'type': 'album',
-            'name': '',
-            'path': None,
-            'random': random.random(),
-            'title': 'Karpe Noktem fotoalbum',
-            'description': "De fotocollectie van Karpe Noktem",
-            'visibility': ['world']}).save()
+            'visibility': [visibility]})
+        album.update_metadata(album.get_parent())
+        album.save()
     c.execute("SELECT id, name, path, visibility, rotation FROM fa_photos")
     print 'fotos'
     for oldId, name, path, visibility, rotation in c.fetchall():
@@ -57,7 +61,7 @@ def main():
             'description': None,
             'visibility': [visibility],
             'rotation': rotation})
-        foto.update_metadata()
+        foto.update_metadata(foto.get_parent())
         foto.save()
     print 'tags'
     c.execute("SELECT photo_id, username FROM fa_tags")

--- a/utils/one-shot/2014-09-27-import-fotos.py
+++ b/utils/one-shot/2014-09-27-import-fotos.py
@@ -24,7 +24,7 @@ def main():
             'title': 'Karpe Noktem fotoalbum',
             'description': "De fotocollectie van Karpe Noktem",
             'visibility': ['world']})
-        root.update_metadata(None)
+        root.update_metadata(None, save=False)
         root.save()
     for oldId, name, path, humanName, visibility, description in c.fetchall():
         if visibility in ('lost', 'deleted'):
@@ -41,7 +41,7 @@ def main():
             'title': humanName,
             'description': description,
             'visibility': [visibility]})
-        album.update_metadata(album.get_parent())
+        album.update_metadata(album.get_parent(), save=False)
         album.save()
     c.execute("SELECT id, name, path, visibility, rotation FROM fa_photos")
     print 'fotos'
@@ -61,7 +61,7 @@ def main():
             'description': None,
             'visibility': [visibility],
             'rotation': rotation})
-        foto.update_metadata(foto.get_parent())
+        foto.update_metadata(foto.get_parent(), save=False)
         foto.save()
     print 'tags'
     c.execute("SELECT photo_id, username FROM fa_tags")


### PR DESCRIPTION
Maak het mogelijk visibilities te veranderen.
Hij houdt rekening met nesting: als een parent (of grandparent) niet bekeken mag worden, dan mag geen enkele entity daarin bekeken worden.
Dit werkt via een recursieve functie om de permissies voor alle child entities goed te zetten. Mocht dat fout gaan (en halverwege crashen), dan zijn alle children voorlopig helemaal niet te zien totdat `update.py` weer opnieuw gedraaid heeft.
Ik wil visibilities van foto's later toe gaan voegen, samen met rotatie en tags. Maar die visibility toevoegen zal heel triviaal zijn.
Nog een TODO puntje: automatisch redirecten naar de login pagina als een album niet publiek is.