### PR TITLE
HTML template voor foto frame

### DIFF
--- a/kn/fotos/api.py
+++ b/kn/fotos/api.py
@@ -25,6 +25,8 @@ def album_json(album, user):
                  'path': child.full_path,
                  'name': child.name,
                  'title': child.title}
+        if child.description:
+            entry['description'] = child.description;
         if child._type == 'foto':
             entry['largeSize'] = child.get_cache_size('large')
             entry['thumbnailSize'] = child.get_cache_size('thumb')

--- a/kn/fotos/media/fotos.css
+++ b/kn/fotos/media/fotos.css
@@ -59,6 +59,9 @@ img.lazy {
     visibility: hidden;
 }
 
+.template {
+    display: none;
+}
 
 /* Keep up to date with fotos.js! (onresize) */
 #foto {
@@ -95,19 +98,27 @@ img.lazy {
     min-height: 300px;
 }
 
-#foto .nav {
+#foto .header,
+#foto .footer {
     padding: 6px 0;
 }
 
-#foto .nav a {
-    display: inline-block;
-}
 #foto .prev {
     float: left;
 }
-#foto .orig,
 #foto .next {
     float: right;
+}
+#foto .header a:not([href]) {
+    display: none;
+}
+
+#foto .footer {
+    text-align: right;
+}
+#foto .description {
+    float: left;
+    margin: 0;
 }
 
 @media (max-width: 500px), (max-height: 500px) {
@@ -118,12 +129,13 @@ img.lazy {
         max-width: 100%;
         padding: 0;
     }
-    #foto .nav {
+    #foto .header,
+    #foto .footer {
         padding: 6px 5px;
     }
 }
 
-#foto img {
+#foto .img {
     padding: 0;
     margin: 0;
     border: 0;

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -227,6 +227,7 @@
   KNF.prototype.change_foto = function(foto) {
     if (this.foto) {
       $('#foto').hide();
+      $('#foto .foto-frame').remove();
       $('html').removeClass('noscroll');
     }
     foto = foto || null;
@@ -239,39 +240,25 @@
       location.hash = '#' + foto.name;
     }
     $('html').addClass('noscroll');
-    var fotoDiv = $('#foto > div');
-    fotoDiv.empty()
+    var frame = $('.foto-frame.template').clone().removeClass('template');
+    frame.appendTo('#foto');
+    $('.title', frame)
+        .text(foto.title ? foto.title : foto.name);
+    if (foto.prev)
+      $('.prev', frame)
+          .attr('href', '#'+foto.prev.name);
+    if (foto.next)
+      $('.next', frame)
+          .attr('href', '#'+foto.next.name);
     var srcset = foto.large + " 1x, " +
                  foto.large2x + " 2x";
-    var navHead = $('<div class="nav"></div>').appendTo(fotoDiv);
-    if (foto.prev)
-      $('<a class="prev">vorige</a>')
-              .attr('href', '#'+foto.prev.name)
-              .appendTo(navHead);
-    $('<span></span>')
-              .text(foto.title ? foto.title : foto.name)
-              .appendTo(navHead);
-    if (foto.next)
-      $('<a class="next">volgende</a>')
-              .attr('href', '#'+foto.next.name)
-              .appendTo(navHead);
-    var img = $('<img/>')
-            .attr('srcset', srcset)
-            .attr('src', foto.large);
-    if (foto.largeSize)
-      img.attr('width', foto.largeSize[0])
-         .attr('height', foto.largeSize[1]);
-    img.appendTo(fotoDiv);
-    var navFooter = $('<div class="nav"></div>')
-              .appendTo(fotoDiv);
-    $('<a class="orig">origineel</a>')
-            .attr('href', foto.full)
-            .appendTo(navFooter);
-    $('<div class="clear"></div>').appendTo(navFooter);
+    $('.img', frame)
+        .attr('srcset', srcset)
+        .attr('src', foto.large)
+    $('.orig', frame)
+        .attr('href', foto.full);
     if (foto.description)
-      $('<p></p>')
-            .text('foto.description')
-            .appendTo(navFooter);
+      $('.description', frame).text(foto.description);
     this.onresize();
     $('#foto').show();
   };
@@ -299,7 +286,7 @@
         width  *= maxHeight/height;
         height *= maxHeight/height;
     }
-    $('#foto img')
+    $('#foto .img')
         .attr('width', width)
         .attr('height', height);
   };

--- a/kn/fotos/templates/fotos/fotos.html
+++ b/kn/fotos/templates/fotos/fotos.html
@@ -54,7 +54,17 @@ if ('srcset' in (new Image())) {
 </div>
 {% endif %}
 <ul id="fotos"></ul>
-<div id="foto">
-<div></div>
+<div id="foto"></div>
+<div class="template foto-frame">
+  <div class="header">
+    <a class="prev">vorige</a>
+    <span class="title"></span>
+    <a class="next">volgende</a>
+  </div>
+  <img class="img"/>
+  <div class="footer">
+    <p class="description"></p>
+    <a href="original">origineel</a>
+  </div>
 </div>
 {% endblock body %}


### PR DESCRIPTION
Voor een paar wijzigingen die ik hierna wil gaan doen (visibility, rotatie en taggen) zou het handig zijn als de HTML in de template kan staan in plaats van in JavaScript, voor meer leesbaarheid. Plus dat dit sowieso al mijn voorkeur heeft omdat ik het er mooier uit vindt zien. Door `.clone()` te gebruiken wordt iedere keer een schone template gebruikt, zonder de DOM aanpassingen van de vorige keer.

Als bonus wordt de description nu ook weergegeven als die er is, maar dat is op zich een aparte (maar verwante) wijziging.

EDIT: NIET MERGEN! er zit een foutje in.