### PR TITLE
IE9 compatibility

### DIFF
--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -288,7 +288,10 @@
     if (this.foto) {
       url += '#' + this.foto.name;
     }
-    if (replace) {
+    if (!('pushState' in history)) {
+      // Downwards compatibility with old browsers, primarily IE9.
+      location.href = url;
+    } else if (replace) {
       history.replaceState(null, '', url);
     } else {
       history.pushState(null, '', url);

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -286,7 +286,7 @@
       url += '?q=' + encodeURIComponent(this.search_query);
     }
     if (this.foto) {
-      url += '#' + foto.name;
+      url += '#' + this.foto.name;
     }
     if (replace) {
       history.replaceState(null, '', url);


### PR DESCRIPTION
Het is niet ideaal, maar zo werkt het wel. En het is een kleine aanpassing voor compatibility.

Er zit een bug in IE10 en IE11 waardoor het nog steeds niet helemaal goed werkt: als je een foto sluit en daarna weer dezelfde opent gebeurt er niks (de onhashchange en onpopstate events vuren niet). Ik zal kijken of ik daar nog iets aan kan doen.

IE8 compatibility is veel meer werk, ik zal een mailtje sturen ter discussie of we dit wel willen doen.