### PR TITLE
Album metadata editor achter een knopje

### DIFF
--- a/kn/fotos/media/edit-icon.svg
+++ b/kn/fotos/media/edit-icon.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="32"
+   height="32"
+   viewBox="0 0 32 32">
+  <path
+     d="m 28.5,3.5 -2,2"
+     style="stroke:#000;stroke-width:10"/>
+  <path
+     d="M 25,7 7,25"
+     style="stroke:#000;stroke-width:10"/>
+  <path
+     d="m 2,23 7,7 -9,2 z"
+     style="fill:#000"/>
+</svg>

--- a/kn/fotos/media/fotos.css
+++ b/kn/fotos/media/fotos.css
@@ -9,9 +9,45 @@
 
 #topbar {
     float: right;
+    position: relative;
 }
-#topbar form {
-    display: inline;
+
+img#album-edit-toggle {
+    margin: 0;
+    box-shadow: none;
+    max-width: none;
+    vertical-align: middle;
+    background: none;
+    opacity: 0.5;
+    padding: 4px;
+    z-index: 2;
+    border: 1px transparent solid;
+    border-bottom: 1px white solid;
+    position: relative;
+    bottom: -1px;
+}
+#album-edit-toggle:hover,
+#topbar.editor #album-edit-toggle {
+    opacity: 1;
+}
+#topbar.editor #album-edit-toggle {
+    background: white;
+    border-color: #aaa;
+    border-bottom: 1px white solid;
+}
+
+#album-editor {
+    display: none;
+    position: absolute;
+    z-index: 1;
+    background: white;
+    white-space: nowrap;
+    right: -5px;
+    padding: 2px 5px;
+    border: 1px #aaa solid;
+}
+#topbar.editor #album-editor {
+    display: block;
 }
 
 p.error {

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -813,4 +813,10 @@
   });
 })();
 
+$(document).ready(function() {
+  $('#album-edit-toggle').click(function() {
+    $('#topbar').toggleClass('editor');
+  });
+});
+
 /* vim: set et sta bs=2 sw=2 : */

--- a/kn/fotos/templates/fotos/fotos.html
+++ b/kn/fotos/templates/fotos/fotos.html
@@ -52,7 +52,8 @@ if ('srcset' in (new Image())) {
 <div id="topbar">
   <input id="search" type="search" placeholder="zoek..."/>
 {% if fotos_admin %}
-  <form>
+  <img id="album-edit-toggle" src="{{ MEDIA_URL }}/fotos/edit-icon.svg" width="16" height="16"/>
+  <form id="album-editor">
     <select id="album-visibility"
       onchange="$('#album-edit-button').prop('disabled', false)">
       <option value="world">Publiek</option>

--- a/kn/fotos/templates/fotos/fotos.html
+++ b/kn/fotos/templates/fotos/fotos.html
@@ -52,7 +52,8 @@ if ('srcset' in (new Image())) {
 <div id="topbar">
   <input id="search" type="search" placeholder="zoek..."/>
 {% if fotos_admin %}
-  <img id="album-edit-toggle" src="{{ MEDIA_URL }}/fotos/edit-icon.svg" width="16" height="16"/>
+  <img id="album-edit-toggle" src="{{ MEDIA_URL }}/fotos/edit-icon.svg"
+    width="16" height="16" title="Bewerk naam en zichtbaarheid"/>
   <form id="album-editor">
     <select id="album-visibility"
       onchange="$('#album-edit-button').prop('disabled', false)">


### PR DESCRIPTION
Verberg de metadata editor achter een edit knopje:
![screenshot](https://cloud.githubusercontent.com/assets/729697/6765944/fcf50de2-cff3-11e4-8375-1c97ec252f31.png)
![screenshot-1](https://cloud.githubusercontent.com/assets/729697/6765943/fcf2aeee-cff3-11e4-9369-884396585deb.png)

@petervdv, wat vind jij er van?