### PR TITLE
Do not add browser history entries for forward/back navigation

### DIFF
--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -291,6 +291,8 @@
     if (this.foto) {
       url += '#' + this.foto.name;
     }
+    if (replace && location.pathname+location.hash === url)
+      return;
     if (!('pushState' in history)) {
       // Downwards compatibility with old browsers, primarily IE9.
       location.href = url;
@@ -362,11 +364,15 @@
     foto = foto || null;
     this.foto = foto;
     if (!foto) {
-      this.apply_url(false);
+      if (this.get_hash() !== '' && 'replaceState' in history) {
+        history.back();
+      } else {
+        this.apply_url(true);
+      }
       return;
     }
     if (this.get_hash() != foto.name) {
-      this.apply_url(false);
+      this.apply_url(true);
     }
     $('html').addClass('noscroll');
     var frame = $('.foto-frame.template').clone().removeClass('template');


### PR DESCRIPTION
Nog niet mergen! Ik zou ook graag de mening van @petervdv weten, aangezien hij hier wat over heeft gezegd in de mail.

Ik vind het persoonlijk onhandig dat als je vooruit en terug gaat in het fotoboek, dit nieuwe entries in de browsergeschiedenis maakt. Heb je een aantal foto's bekeken, kun je niet zomaar weer op 'terug' drukken om bij het album uit te komen, dan moet je door al die foto's heen. En mij lijkt het ook niet heel nuttig om een terugknop bij het bladeren door een album te hebben als je al vooruit en achteruit knoppen (en toetsen!) hebt.
Daarom deze aanpassing. Nu werkt de terug knop in de browser hetzelfde als de `<Esc>` knop op het toetsenbord.
Nog een reden: dit werkt prettiger op mobieltjes, waar geen `<Esc>` knop is en naast de foto klikken moeilijker gaat.

Bovendien hoop ik dat dit een probleempje in IE10/IE11 verhelpt, maar dat is niet de primaire reden voor deze pull request.