### PR TITLE
Performance

### DIFF
--- a/kn/fotos/entities.py
+++ b/kn/fotos/entities.py
@@ -555,6 +555,7 @@ class Foto(FotoEntity):
                          '-strip',
                          '-rotate', str(self.rotation),
                          '-resize', size,
+                         '-interlace', 'Plane',
                          '-quality', str(self.CACHES[cache].quality),
                          target])
 


### PR DESCRIPTION
Twee issues verholpen.

Ik had eerder geen progressieve JPEG gebruikt aangezien het niet goed zou zijn voor usability, maar op mobieltjes is het echt wel een grote verbetering (vooral met `large2x`). Bovendien, Google gebruikt het ook dus zo slecht kan het niet zijn. Zonder progressieve JPEG duurt het zo'n 5 seconde voordat een foto geladen is over 'regular 3G', met is het ongeveer een seconde.

Uiteindelijk is het de bedoeling om over te schakelen op een server die een fatsoenlijke X-Sendfile achtige implementatie heeft (nginx), maar ook dan kan deze check geen kwaad.